### PR TITLE
Fix Image picker on iOS:- APPSCORE 20390

### DIFF
--- a/Example/TLPhotoPicker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/TLPhotoPicker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Resolved a critical issue in the TLPhotoPicker dependency used in the `fk-ios-app` repository. The problem involved the image picker, where the middle column of a three-column layout was blank, leaving no images displayed. The issue was identified and fixed, ensuring all three columns display images correctly, improving the overall user experience in the image picker section.